### PR TITLE
Change reference Asv.Tools to Asv.IO

### DIFF
--- a/src/Asv.Mavlink.Shell/Resources/csharp.tpl
+++ b/src/Asv.Mavlink.Shell/Resources/csharp.tpl
@@ -26,7 +26,7 @@ using System;
 using System.Text;
 using Asv.Mavlink.V2.Common;
 using Asv.Mavlink.V2.Minimal;
-using Asv.Tools;
+using Asv.IO;
 
 namespace Asv.Mavlink.V2.{{ Namespace }}
 {


### PR DESCRIPTION
According to https://github.com/asvol/asv-mavlink/issues/1

Since Asv.Tools changed into Asv.IO